### PR TITLE
Separate internal and external api ports

### DIFF
--- a/assets.tf
+++ b/assets.tf
@@ -37,7 +37,7 @@ resource "template_dir" "manifests" {
     apiserver_port         = "${var.apiserver_port}"
 
     ca_cert            = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
-    server             = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+    server             = "${format("https://%s:%s", element(var.api_servers, 0), var.server_port)}"
     apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
     apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
     serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
@@ -68,7 +68,7 @@ data "template_file" "kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.server_port)}"
   }
 }
 
@@ -80,6 +80,6 @@ data "template_file" "user-kubeconfig" {
     ca_cert      = "${base64encode(var.ca_certificate == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_certificate)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.apiserver_port)}"
+    server       = "${format("https://%s:%s", element(var.api_servers, 0), var.server_port)}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,13 @@ variable "ca_private_key" {
 # unofficial, temporary, may be removed without notice
 
 variable "apiserver_port" {
-  description = "kube-apiserver port"
+  description = "kube-apiserver port (internal, the one the process uses)"
+  type        = "string"
+  default     = "6443"
+}
+
+variable "server_port" {
+  description = "kube-apiserver port (external, the one the apiserver endpoint uses)"
   type        = "string"
   default     = "6443"
 }


### PR DESCRIPTION
We will need to maintain this change in our fork for the time being. See  https://github.com/poseidon/terraform-render-bootkube/issues/72 for details

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>